### PR TITLE
Fix problem of multiple service workers being registered over multiple URLs

### DIFF
--- a/pwa/templates/pwa.html
+++ b/pwa/templates/pwa.html
@@ -36,7 +36,7 @@
     // Initialize the service worker
     if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/serviceworker.js', {
-            scope: '.'
+            scope: '/'
         }).then(function (registration) {
             // Registration was successful
             console.log('django-pwa: ServiceWorker registration successful with scope: ', registration.scope);

--- a/tests/test_template_tag_meta.py
+++ b/tests/test_template_tag_meta.py
@@ -53,7 +53,7 @@ class CreateMetaTemplateTagTest(TestCase):
             '<script type="text/javascript">',
             "if ('serviceWorker' in navigator) {",
             "navigator.serviceWorker.register('/serviceworker.js', {",
-            "scope: '.'",
+            "scope: '/'",
             "}).then(function (registration) {",
             "console.log('django-pwa: ServiceWorker registration successful with scope: ', registration.scope);",
             "}, function (err) {",


### PR DESCRIPTION
Source:
https://stackoverflow.com/questions/33816342/how-to-prevent-the-same-service-worker-from-registering-over-multiple-pages