### PR TITLE
for using custom PWA_APP_ICONS src path, define STATICFILES_DIRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ INSTALLED_APPS = [
     ...
 ]
 ```
+Define STATICFILES_DIRS for your custom PWA_APP_ICONS
+```python
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static'),
+]
+```
 
 Configure your app name, description, icons and splash screen images in settings.py:
 ```python


### PR DESCRIPTION
if STATICFILES_DIRS is not defined, src path(/static/images) only point pwa's below static folder 
