### PR TITLE
Allow view names in settings and mounting at subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,4 +58,10 @@
   ### Added
   - Updated manifest.json by adding scope parameter.
   - Updated serviceworker.js add scope dynamic parameter
- 
+
+ ## 1.0.7
+
+  ### Fixed
+  - Fix PWA if app is not mounted in root of webserver
+  ### Added
+  - Allow use of view names in PWA_APP_SCOPE, PWA_START_URL, PWA_APP_FETCH_URL and PWA_APP_ROOT

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -1,6 +1,11 @@
 """ Settings required by django-app. """
 from django.conf import settings
+from django.shortcuts import resolve_url
+from django.urls import get_script_prefix
 import os
+
+# Get script prefix for apps not mounted under /
+_PWA_SCRIPT_PREFIX = get_script_prefix()
 
 # Path to the service worker implementation.  Default implementation is empty.
 PWA_SERVICE_WORKER_PATH = getattr(settings, 'PWA_SERVICE_WORKER_PATH',
@@ -9,15 +14,15 @@ PWA_SERVICE_WORKER_PATH = getattr(settings, 'PWA_SERVICE_WORKER_PATH',
 # App parameters to include in manifest.json and appropriate meta tags
 PWA_APP_NAME = getattr(settings, 'PWA_APP_NAME', 'MyApp')
 PWA_APP_DESCRIPTION = getattr(settings, 'PWA_APP_DESCRIPTION', 'My Progressive Web App')
-PWA_APP_ROOT_URL = getattr(settings, 'PWA_APP_ROOT_URL', '/')
+PWA_APP_ROOT_URL = resolve_url(getattr(settings, 'PWA_APP_ROOT_URL', _PWA_SCRIPT_PREFIX))
 PWA_APP_THEME_COLOR = getattr(settings, 'PWA_APP_THEME_COLOR', '#000')
 PWA_APP_BACKGROUND_COLOR = getattr(settings, 'PWA_APP_BACKGROUND_COLOR', '#fff')
 PWA_APP_DISPLAY = getattr(settings, 'PWA_APP_DISPLAY', 'standalone')
-PWA_APP_SCOPE = getattr(settings, 'PWA_APP_SCOPE', '/')
+PWA_APP_SCOPE = resolve_url(getattr(settings, 'PWA_APP_SCOPE', _PWA_SCRIPT_PREFIX))
 PWA_APP_DEBUG_MODE = getattr(settings, 'PWA_APP_DEBUG_MODE', True)
 PWA_APP_ORIENTATION = getattr(settings, 'PWA_APP_ORIENTATION', 'any')
-PWA_APP_START_URL = getattr(settings, 'PWA_APP_START_URL', '/')
-PWA_APP_FETCH_URL = getattr(settings, 'PWA_APP_FETCH_URL', '/')
+PWA_APP_START_URL = resolve_url(getattr(settings, 'PWA_APP_START_URL', _PWA_SCRIPT_PREFIX))
+PWA_APP_FETCH_URL = resolve_url(getattr(settings, 'PWA_APP_FETCH_URL', _PWA_SCRIPT_PREFIX))
 PWA_APP_ICONS = getattr(settings, 'PWA_APP_ICONS', [
     {
         'src': '/static/images/icons/icon-72x72.png',


### PR DESCRIPTION
Administrators might mount a Django app anywhere under there webserver, not at the root. PWA's defaults should be agnostic of that, for which Django handlesthe situation in `reverse` and with a helper `get_script_prefix`.

While implementing that, we got the ability to specify a view name instead of a URL for free through the same mechanism.