### PR TITLE
Escape wildcard in paths

### DIFF
--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -4,7 +4,7 @@ from .views import manifest, service_worker, offline
 
 # Serve up serviceworker.js and manifest.json at the root
 urlpatterns = [
-    url('^serviceworker.js$', service_worker, name='serviceworker'),
-    url('^manifest.json$', manifest, name='manifest'),
+    url(r'^serviceworker\.js$', service_worker, name='serviceworker'),
+    url(r'^manifest\.json$', manifest, name='manifest'),
     url('^offline/$', offline, name='offline')
 ]


### PR DESCRIPTION
Both serviceworker.js and manifest.json load even if the '.' character is replaced by any other character. This regex fix will prevent that.