### PR TITLE
Fix for #52 where manifest cant be found on CompressedManifestStaticF…

### DIFF
--- a/pwa/templates/offline.html
+++ b/pwa/templates/offline.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Default offline template</title>
-    <link href="{% static '/css/django-pwa-app.css' %}" rel="stylesheet">
+    <link href="{% static 'css/django-pwa-app.css' %}" rel="stylesheet">
 </head>
 <body>
 <h1>You are currently not connected to any networks.</h1>


### PR DESCRIPTION
This proposal is to drop an inicial `/` at the `{% static %}` tag at offline.html. I ran the tests and the seem fine. 
Thank you in advance.