### PR TITLE
Fix service worker script URL if app is not mounted in root of webserver

### DIFF
--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -11,6 +11,9 @@ resolve_url = lazy(resolve_url, str)
 # Get script prefix for apps not mounted under /
 _PWA_SCRIPT_PREFIX = get_script_prefix()
 
+# Path to the service worker script that will be registered
+PWA_SERVICE_WORKER_SCRIPT_URL = _PWA_SCRIPT_PREFIX + 'serviceworker.js'
+
 # Path to the service worker implementation.  Default implementation is empty.
 PWA_SERVICE_WORKER_PATH = getattr(settings, 'PWA_SERVICE_WORKER_PATH',
                                   os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates',

--- a/pwa/templates/pwa.html
+++ b/pwa/templates/pwa.html
@@ -42,7 +42,7 @@
 <script type="text/javascript">
     // Initialize the service worker
     if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('/serviceworker.js', {
+	    navigator.serviceWorker.register('{{ PWA_SERVICE_WORKER_SCRIPT_URL }}', {
             scope: '{{ PWA_APP_SCOPE }}'
         }).then(function (registration) {
             // Registration was successful


### PR DESCRIPTION
... specifically when building and deploying server-less Django with [zappa](https://github.com/zappa/Zappa)