### PR TITLE
Replace django.conf.urls.url with django.urls.re_path

### DIFF
--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -1,10 +1,17 @@
-from django.conf.urls import url
+from django.utils import version
+
+DJANGO_VERSION = version.get_version()
+
+if int(DJANGO_VERSION[0]) >= 2:
+    from django.urls import re_path
+else:  # pragma: no cover
+    from django.conf.urls import url as re_path
 
 from .views import manifest, service_worker, offline
 
 # Serve up serviceworker.js and manifest.json at the root
 urlpatterns = [
-    url(r'^serviceworker\.js$', service_worker, name='serviceworker'),
-    url(r'^manifest\.json$', manifest, name='manifest'),
-    url('^offline/$', offline, name='offline')
+    re_path(r"^serviceworker\.js$", service_worker, name="serviceworker"),
+    re_path(r"^manifest\.json$", manifest, name="manifest"),
+    re_path("^offline/$", offline, name="offline"),
 ]


### PR DESCRIPTION
This avoid a deprecation warning: django.conf.urls.url is an alias for
django.urls.re_path but will be removed in Django 4.0.

This method was only added in Django 2.0, so we have to check
whether we are using a version of Django greater than 2.0 before
we import it. Otherwise, we use the old `url` method.

Fixes #68