### PR TITLE
Deprecate support of Django < 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 install_requirements = [
-    "django>=1.8",
+    "django>=1.10",
 ]
 
 setup(
@@ -34,8 +34,6 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py35-django{18,19,110,111,20,21}
+    py35-django{110,111,20,21}
     py36-django{20}
     py36-django{21}
     py37-django{20}
@@ -19,8 +19,6 @@ basepython =
     py37: python3.7
     py38: python3.8
 deps =
-    django18: django==1.8
-    django19: django==1.9
     django110: django==1.10
     django111: django==1.11
     django20: Django==2.0


### PR DESCRIPTION
We do not support Django < 1.10 (the tests will not run because of an
import of a package that does not exist prior to Django 1.10), so we
should make that support explicit.