### PR TITLE
Add exclude for tests from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requirements = [
 setup(
     name='django-pwa',
     version='1.0.10',
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     install_requires=install_requirements,
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
Fixes #61 

See below for a diff of a run of `python setup.py sdist`.

NB: You will need to delete the `django-pwa.egg-info` to ensure this change occurs, otherwise the files will still be in the built image.

```diff
running sdist
running egg_info
writing django_pwa.egg-info/PKG-INFO
writing dependency_links to django_pwa.egg-info/dependency_links.txt
writing requirements to django_pwa.egg-info/requires.txt
writing top-level names to django_pwa.egg-info/top_level.txt
reading manifest file 'django_pwa.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'django_pwa.egg-info/SOURCES.txt'
running check
creating django-pwa-1.0.10
creating django-pwa-1.0.10/django_pwa.egg-info
creating django-pwa-1.0.10/pwa
creating django-pwa-1.0.10/pwa/static
creating django-pwa-1.0.10/pwa/static/css
creating django-pwa-1.0.10/pwa/static/fonts
creating django-pwa-1.0.10/pwa/static/fonts/bootstrap
creating django-pwa-1.0.10/pwa/static/images
creating django-pwa-1.0.10/pwa/static/images/icons
creating django-pwa-1.0.10/pwa/templates
creating django-pwa-1.0.10/pwa/templatetags
creating django-pwa-1.0.10/tests
copying files to django-pwa-1.0.10...
copying CHANGELOG.md -> django-pwa-1.0.10
copying LICENSE.md -> django-pwa-1.0.10
copying MANIFEST.in -> django-pwa-1.0.10
copying README.md -> django-pwa-1.0.10
copying setup.py -> django-pwa-1.0.10
copying django_pwa.egg-info/PKG-INFO -> django-pwa-1.0.10/django_pwa.egg-info
copying django_pwa.egg-info/SOURCES.txt -> django-pwa-1.0.10/django_pwa.egg-info
copying django_pwa.egg-info/dependency_links.txt -> django-pwa-1.0.10/django_pwa.egg-info
copying django_pwa.egg-info/requires.txt -> django-pwa-1.0.10/django_pwa.egg-info
copying django_pwa.egg-info/top_level.txt -> django-pwa-1.0.10/django_pwa.egg-info
copying pwa/__init__.py -> django-pwa-1.0.10/pwa
copying pwa/app_settings.py -> django-pwa-1.0.10/pwa
copying pwa/apps.py -> django-pwa-1.0.10/pwa
copying pwa/urls.py -> django-pwa-1.0.10/pwa
copying pwa/views.py -> django-pwa-1.0.10/pwa
copying pwa/static/css/django-pwa-app.css -> django-pwa-1.0.10/pwa/static/css
copying pwa/static/fonts/bootstrap/glyphicons-halflings-regular.eot -> django-pwa-1.0.10/pwa/static/fonts/bootstrap
copying pwa/static/fonts/bootstrap/glyphicons-halflings-regular.svg -> django-pwa-1.0.10/pwa/static/fonts/bootstrap
copying pwa/static/fonts/bootstrap/glyphicons-halflings-regular.ttf -> django-pwa-1.0.10/pwa/static/fonts/bootstrap
copying pwa/static/fonts/bootstrap/glyphicons-halflings-regular.woff -> django-pwa-1.0.10/pwa/static/fonts/bootstrap
copying pwa/static/fonts/bootstrap/glyphicons-halflings-regular.woff2 -> django-pwa-1.0.10/pwa/static/fonts/bootstrap
copying pwa/static/images/icons/Thumbs.db -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-128x128.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-144x144.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-152x152.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-192x192.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-384x384.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-512x512.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-72x72.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/icon-96x96.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-1125x2436.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-1242x2208.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-1242x2688.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-1536x2048.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-1668x2224.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-1668x2388.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-2048x2732.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-640x1136.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-750x1334.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/static/images/icons/splash-828x1792.png -> django-pwa-1.0.10/pwa/static/images/icons
copying pwa/templates/manifest.json -> django-pwa-1.0.10/pwa/templates
copying pwa/templates/offline.html -> django-pwa-1.0.10/pwa/templates
copying pwa/templates/pwa.html -> django-pwa-1.0.10/pwa/templates
copying pwa/templates/serviceworker.js -> django-pwa-1.0.10/pwa/templates
copying pwa/templatetags/__init__.py -> django-pwa-1.0.10/pwa/templatetags
copying pwa/templatetags/pwa.py -> django-pwa-1.0.10/pwa/templatetags
- copying tests/__init__.py -> django-pwa-1.0.10/tests
- copying tests/settings.py -> django-pwa-1.0.10/tests
- copying tests/test_settings_attr.py -> django-pwa-1.0.10/tests
- copying tests/test_template_tag_meta.py -> django-pwa-1.0.10/tests
- copying tests/test_view.py -> django-pwa-1.0.10/tests
Writing django-pwa-1.0.10/setup.cfg
creating dist
Creating tar archive
removing 'django-pwa-1.0.10' (and everything under it)
```