### PR TITLE
Added PWA screenshots and shortcut support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ STATICFILES_DIRS = [
 ]
 ```
 
-Configure your app name, description, icons and splash screen images in settings.py:
+Configure your app name, description, icons, splash screen images, screenshots and shortcuts in settings.py:
 ```python
 
 PWA_APP_NAME = 'My App'
@@ -75,12 +75,27 @@ PWA_APP_SPLASH_SCREEN = [
 ]
 PWA_APP_DIR = 'ltr'
 PWA_APP_LANG = 'en-US'
+PWA_APP_SHORTCUTS = [
+    {
+        'name': 'Shortcut',
+        'url': '/target',
+        'description': 'Shortcut to a page in my application'
+    }
+]
+PWA_APP_SCREENSHOTS = [
+    {
+      'src': '/static/images/icons/splash-750x1334.png',
+      'sizes': '750x1334',
+      "type": "image/png"
+    }
+]
 
 ```
 #### Show console.log
 Set the `PWA_APP_DEBUG_MODE = False` to disable the the `console.log` on browser. 
 
 All settings are optional, and the app will work fine with its internal defaults.  Highly recommend setting at least `PWA_APP_NAME`, `PWA_APP_DESCRIPTION`, `PWA_APP_ICONS` and `PWA_APP_SPLASH_SCREEN`.
+In order to not use one of the internal defaults, a setting can be set to an empty string or list, whichever one is applicable.
 
 Add the progressive web app URLs to urls.py:
 ```python
@@ -109,10 +124,10 @@ Troubleshooting
 While running the Django test server:
 
 1. Verify that `/manifest.json` is being served
-1. Verify that `/serviceworker.js` is being served
-1. Verify that `/offline` is being served
-1. Use the Application tab in the Chrome Developer Tools to verify the progressive web app is configured correctly.
-1. Use the "Add to homescreen" link on the Application Tab to verify you can add the app successfully.
+2. Verify that `/serviceworker.js` is being served
+3. Verify that `/offline` is being served
+4. Use the Application tab in the Chrome Developer Tools to verify the progressive web app is configured correctly.
+5. Use the "Add to homescreen" link on the Application Tab to verify you can add the app successfully.
 
 
 The Service Worker

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -107,3 +107,10 @@ PWA_APP_SPLASH_SCREEN = getattr(settings, 'PWA_APP_SPLASH_SCREEN', [
 ])
 PWA_APP_DIR = getattr(settings, 'PWA_APP_DIR', 'auto')
 PWA_APP_LANG = getattr(settings, 'PWA_APP_LANG', 'en-US')
+PWA_APP_SCREENSHOTS = getattr(settings, 'PWA_APP_SCREENSHOTS', [
+    {
+      'src': '/static/images/icons/splash-750x1334.png',
+      'sizes': '750x1334',
+      "type": "image/png"
+    }
+  ])

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -114,3 +114,10 @@ PWA_APP_SCREENSHOTS = getattr(settings, 'PWA_APP_SCREENSHOTS', [
       "type": "image/png"
     }
   ])
+PWA_APP_SHORTCUTS = getattr(settings, "PWA_APP_SHORTCUTS", [
+    {
+        'name': 'Home',
+        'url': '/',
+        'description': 'Startpage of the application'
+    }
+])

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -107,17 +107,5 @@ PWA_APP_SPLASH_SCREEN = getattr(settings, 'PWA_APP_SPLASH_SCREEN', [
 ])
 PWA_APP_DIR = getattr(settings, 'PWA_APP_DIR', 'auto')
 PWA_APP_LANG = getattr(settings, 'PWA_APP_LANG', 'en-US')
-PWA_APP_SCREENSHOTS = getattr(settings, 'PWA_APP_SCREENSHOTS', [
-    {
-      'src': '/static/images/icons/splash-750x1334.png',
-      'sizes': '750x1334',
-      "type": "image/png"
-    }
-  ])
-PWA_APP_SHORTCUTS = getattr(settings, "PWA_APP_SHORTCUTS", [
-    {
-        'name': 'Home',
-        'url': '/',
-        'description': 'Startpage of the application'
-    }
-])
+PWA_APP_SCREENSHOTS = getattr(settings, 'PWA_APP_SCREENSHOTS', [])
+PWA_APP_SHORTCUTS = getattr(settings, "PWA_APP_SHORTCUTS", [])

--- a/pwa/templates/manifest.json
+++ b/pwa/templates/manifest.json
@@ -13,5 +13,6 @@
   "icons": {{ PWA_APP_ICONS|js }},
   "dir": {{ PWA_APP_DIR|js }},
   "lang": {{ PWA_APP_LANG|js }},
-  "screenshots" : {{PWA_APP_SCREENSHOTS|js }}
+  "screenshots" : {{PWA_APP_SCREENSHOTS|js }},
+  "shortcuts" : {{PWA_APP_SHORTCUTS|js }}
 }

--- a/pwa/templates/manifest.json
+++ b/pwa/templates/manifest.json
@@ -12,5 +12,6 @@
   "status_bar": {{ PWA_APP_STATUS_BAR_COLOR|js }},
   "icons": {{ PWA_APP_ICONS|js }},
   "dir": {{ PWA_APP_DIR|js }},
-  "lang": {{ PWA_APP_LANG|js }}
+  "lang": {{ PWA_APP_LANG|js }},
+  "screenshots" : {{PWA_APP_SCREENSHOTS|js }}
 }

--- a/tests/test_settings_attr.py
+++ b/tests/test_settings_attr.py
@@ -20,7 +20,8 @@ class AppSettingsTest(TestCase):
             'PWA_APP_ICONS',
             'PWA_APP_DIR',
             'PWA_APP_LANG',
-            'PWA_APP_STATUS_BAR_COLOR'
+            'PWA_APP_STATUS_BAR_COLOR',
+            'PWA_APP_SCREENSHOTS'
         ]
         for attr in attributes:
             with self.subTest():

--- a/tests/test_settings_attr.py
+++ b/tests/test_settings_attr.py
@@ -21,7 +21,8 @@ class AppSettingsTest(TestCase):
             'PWA_APP_DIR',
             'PWA_APP_LANG',
             'PWA_APP_STATUS_BAR_COLOR',
-            'PWA_APP_SCREENSHOTS'
+            'PWA_APP_SCREENSHOTS',
+            'PWA_APP_SHORTCUTS'
         ]
         for attr in attributes:
             with self.subTest():

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -28,7 +28,7 @@ class ManifestTest(TestCase):
         self.assertTemplateUsed(self.response, 'manifest.json')
 
     def test_manifest_contains(self):
-        """Must be the attributes to manitesf.json"""
+        """Must be the attributes to manifest.json"""
         contents = [
             '"name":',
             '"short_name":',
@@ -42,7 +42,8 @@ class ManifestTest(TestCase):
             '"icons":',
             '"dir":',
             '"lang":',
-            '"status_bar":'
+            '"status_bar":',
+            '"screenshots" :'
         ]
         for expected in contents:
             with self.subTest():

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -43,7 +43,8 @@ class ManifestTest(TestCase):
             '"dir":',
             '"lang":',
             '"status_bar":',
-            '"screenshots" :'
+            '"screenshots" :',
+            '"shortcuts" :'
         ]
         for expected in contents:
             with self.subTest():


### PR DESCRIPTION
Added support for PWA screenshots as described in [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots) and PWA shortcuts as described in [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/Manifest/shortcuts)