### PR TITLE
Fix sizes property name to size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ PWA_APP_STATUS_BAR_COLOR = 'default'
 PWA_APP_ICONS = [
     {
         'src': '/static/images/my_app_icon.png',
-        'sizes': '160x160'
+        'size': '160x160'
     }
 ]
 PWA_APP_ICONS_APPLE = [
     {
         'src': '/static/images/my_apple_icon.png',
-        'sizes': '160x160'
+        'size': '160x160'
     }
 ]
 PWA_APP_SPLASH_SCREEN = [


### PR DESCRIPTION
Fix #38 
The `sizes` property name in README doesn't match with the code, where is it named `size`: https://github.com/silviolleite/django-pwa/blob/0ff60e7afaf23d6883d593554b93e54bb56e41fe/pwa/templates/pwa.html#L19