### PR TITLE
modified pwa/urls.py to use re_path to solve django.url import error …

### DIFF
--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import manifest, service_worker, offline
 
 # Serve up serviceworker.js and manifest.json at the root
 urlpatterns = [
-    url(r'^serviceworker\.js$', service_worker, name='serviceworker'),
-    url(r'^manifest\.json$', manifest, name='manifest'),
-    url('^offline/$', offline, name='offline')
+    re_path(r'^serviceworker\.js$', service_worker, name='serviceworker'),
+    re_path(r'^manifest\.json$', manifest, name='manifest'),
+    re_path('^offline/$', offline, name='offline')
 ]


### PR DESCRIPTION
I saw some users reporting the following error: "ImportError: cannot import name 'url' from 'django.urls'". I solved it by replacing urls with  re_path() instead. Please revise. 