### PR TITLE
Update urls.py

### DIFF
--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import manifest, service_worker, offline
 
 # Serve up serviceworker.js and manifest.json at the root
 urlpatterns = [
-    url(r'^serviceworker\.js$', service_worker, name='serviceworker'),
-    url(r'^manifest\.json$', manifest, name='manifest'),
-    url('^offline/$', offline, name='offline')
+    re_path(r'^serviceworker\.js$', service_worker, name='serviceworker'),
+    re_path(r'^manifest\.json$', manifest, name='manifest'),
+    re_path('^offline/$', offline, name='offline')
 ]


### PR DESCRIPTION
There's update in django 4.0.5. from django.urls.conf has been removed and from django.urls import re_path is used kindly update this in repo