### PR TITLE
Custom manifest.json and fixed some issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .tox/
 .coverage
 .DS_Store
+venv

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Configure your app name, description, icons and splash screen images in settings
 ```python
 
 PWA_APP_NAME = 'My App'
+PWA_APP_SHORT_NAME = 'My App Short Name'
 PWA_APP_DESCRIPTION = "My app description"
 PWA_APP_THEME_COLOR = '#0A0302'
 PWA_APP_BACKGROUND_COLOR = '#ffffff'
@@ -58,13 +59,13 @@ PWA_APP_STATUS_BAR_COLOR = 'default'
 PWA_APP_ICONS = [
     {
         'src': '/static/images/my_app_icon.png',
-        'sizes': '160x160'
+        'size': '160x160'
     }
 ]
 PWA_APP_ICONS_APPLE = [
     {
         'src': '/static/images/my_apple_icon.png',
-        'sizes': '160x160'
+        'size': '160x160'
     }
 ]
 PWA_APP_SPLASH_SCREEN = [
@@ -186,10 +187,13 @@ self.addEventListener("fetch", event => {
 
 Adding Your Own Service Worker
 =====
-To add service worker functionality, you'll want to create a `serviceworker.js` or similarly named template in a template directory, and then point at it using the PWA_SERVICE_WORKER_PATH variable (PWA_APP_FETCH_URL is passed through).
+To add service worker and manifest functionality, you'll want to create a `serviceworker.js` and `manifest.json` respectively or similarly named template in a template directory, and then point at it using the PWA_SERVICE_WORKER_PATH and PWA_MANIFEST_PATH variable (PWA_APP_FETCH_URL is passed through).
 
 ```python
 PWA_SERVICE_WORKER_PATH = os.path.join(BASE_DIR, 'my_app', 'serviceworker.js')
+
+PWA_MANIFEST_PATH = os.path.join(BASE_DIR, 'my_app',
+'manifest.json')
 
 ```
 

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -15,8 +15,16 @@ _PWA_SCRIPT_PREFIX = get_script_prefix()
 PWA_SERVICE_WORKER_PATH = getattr(settings, 'PWA_SERVICE_WORKER_PATH',
                                   os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates',
                                                'serviceworker.js'))
+
+# Path to the manifest implementation.
+PWA_MANIFEST_PATH = getattr(settings,'PWA_MANIFEST_PATH', 
+                            os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates',
+                                        'manifest.json'))
+
+
 # App parameters to include in manifest.json and appropriate meta tags
 PWA_APP_NAME = getattr(settings, 'PWA_APP_NAME', 'MyApp')
+PWA_APP_SHORT_NAME = getattr(settings,'PWA_APP_SHORT_NAME','My App Short Name')
 PWA_APP_DESCRIPTION = getattr(settings, 'PWA_APP_DESCRIPTION', 'My Progressive Web App')
 PWA_APP_ROOT_URL = resolve_url(getattr(settings, 'PWA_APP_ROOT_URL', _PWA_SCRIPT_PREFIX))
 PWA_APP_THEME_COLOR = getattr(settings, 'PWA_APP_THEME_COLOR', '#000')

--- a/pwa/templates/manifest.json
+++ b/pwa/templates/manifest.json
@@ -1,7 +1,7 @@
 {% load pwa %}
 {
   "name": {{ PWA_APP_NAME|js }},
-  "short_name": {{ PWA_APP_NAME|js }},
+  "short_name": {{ PWA_APP_SHORT_NAME|js }},
   "description": {{ PWA_APP_DESCRIPTION|js }},
   "start_url": {{ PWA_APP_START_URL|js }},
   "display": {{ PWA_APP_DISPLAY|js }},

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -10,12 +10,15 @@ def service_worker(request):
 
 
 def manifest(request):
+    response = HttpResponse(open(app_settings.PWA_MANIFEST_PATH).read(), content_type='application/json')
+    if response != None and response != '':
+        return response
     return render(request, 'manifest.json', {
         setting_name: getattr(app_settings, setting_name)
         for setting_name in dir(app_settings)
         if setting_name.startswith('PWA_')
     }, content_type='application/json')
-
+    
 
 def offline(request):
     return render(request, "offline.html")


### PR DESCRIPTION
#37    Miss content_type on manifest.json
--------------------------------------------------------
Fixed with custom file option like serviceworker, by setting a path variable  `PWA_MANIFEST_PATH` at the settings.py
               
#38     sizes not in html
--------------------------------------------------------
Corrected the `README.md` file for the tutorial to use django-pwa

#59     Custom manifest.json
--------------------------------------------------------
Fixed with custom file option like serviceworker, by setting a path variable  `PWA_MANIFEST_PATH` at the settings.py

#70     Short Name Setting Not added
--------------------------------------------------------
Created a variable to choose the `SHORT NAME` by using the variable `PWA_APP_SHORT_NAME`
