### PR TITLE
Fix path to static

### DIFF
--- a/pwa/templates/offline.html
+++ b/pwa/templates/offline.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Default offline template</title>
-    <link href="{% static '/css/django-pwa-app.css' %}" rel="stylesheet">
+    <link href="{% static 'css/django-pwa-app.css' %}" rel="stylesheet">
 </head>
 <body>
 <h1>You are currently not connected to any networks.</h1>

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requirements = [
 
 setup(
     name='django-pwa',
-    version='1.1.0',
+    version='1.1.1',
     packages=find_packages(),
     install_requires=install_requirements,
     include_package_data=True,


### PR DESCRIPTION
Missing staticfiles error appears:

```
ValueError at /offline/
Missing staticfiles manifest entry for '/css/django-pwa-app.css'
```