### PR TITLE
fix: close serviceworker.js file

### DIFF
--- a/pwa/views.py
+++ b/pwa/views.py
@@ -5,9 +5,11 @@ from . import app_settings
 
 
 def service_worker(request):
-    response = HttpResponse(
-        open(app_settings.PWA_SERVICE_WORKER_PATH).read(), content_type="application/javascript"
-    )
+    with open(app_settings.PWA_SERVICE_WORKER_PATH) as serviceworker_file:
+        response = HttpResponse(
+            serviceworker_file.read(),
+            content_type="application/javascript",
+        )
     return response
 
 


### PR DESCRIPTION
Django automatically read and close file-like objects passed to responses.