### PR TITLE
Small fix in offline template

### DIFF
--- a/pwa/templates/offline.html
+++ b/pwa/templates/offline.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Default offline template</title>
-    <link href="{% static '/css/django-pwa-app.css' %}" rel="stylesheet">
+    <link href="{% static 'css/django-pwa-app.css' %}" rel="stylesheet">
 </head>
 <body>
 <h1>You are currently not connected to any networks.</h1>


### PR DESCRIPTION
Hi there :wave: 

The `offline` template crashes when static files are collected using `django.contrib.staticfiles.storage.ManifestStaticFilesStorage`, because some CSS file is called with an absolute path.

This PR just makes the CSS file path relative.

Fixes #57 and #52